### PR TITLE
allow customizing wait page js part

### DIFF
--- a/otree_mturk_utils/templates/otree_mturk_utils/CustomWaitPage.html
+++ b/otree_mturk_utils/templates/otree_mturk_utils/CustomWaitPage.html
@@ -1,4 +1,4 @@
-{% extends 'otree/WaitPage.html' %}
+{% extends 'otree_mturk_utils/GenericExtendedWaitPage.html' %}
 {% load staticfiles otree_tags %}
 {% block title %}Please wait!{% endblock %}
 {% block styles %}

--- a/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPage.html
+++ b/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPage.html
@@ -1,0 +1,36 @@
+{% extends 'otree/WaitPage.html' %}
+{% load staticfiles otree_tags %}
+
+
+
+
+{% comment %}
+
+        If you want to add your own behaviour to the custom wait page, for example, in order to "smooth" the exit of the page when a group is formed, you can replace all the content of this page, including the extension declaration at the top of it, with the complete content of the WaitPage that you can find in WaitPage of the otree core installation that you are using (the template that this file currently extends).
+
+        For now, you can find that otree core version, for the last version, at this address: https://github.com/oTree-org/otree-core/blob/master/otree/templates/otree/WaitPage.html
+
+        Then you can add your own content, for example in the socket.onmessage part, if you want something special to happen, when the page receives the signal that a group has been formed.
+
+        Be careful, the WaitPage in otree core can change from an oTree version to another: If you update otree core, you might need to adapt this page, with the new otree core WaitPage.html.
+
+        You will find an example, in GenericExtendedWaitPageExample1ForOTree140.html, that is based on the WaitPage of oTree core 140. This is just a quick and dirty extension, that only shows an ugly alert box, in order to warn the participant that he will be forwarded to the next page, when the group is matched
+        ((just added: "alert('Enough persons have arrived, you will be transfered to the next page; You will be invited to finish your study at the end of the experiment');"))
+
+        In the second example, GenericExtendedWaitPageExample2ForOTree140.html, a hidden message is shown via 
+                <div class="well" id="show-when-group-is-formed" style="display:none; color:red;">
+                    <b>Enough persons have arrived, you will be transfered to the next page; You will be invited to finish your study at the end of the experiment.</b>
+                </div>
+
+                and
+                $("#show-when-group-is-formed").show();
+
+        and the redirection is delayed by 10s (10 000 ms)
+            window.setInterval(function() {
+                  window.location.href = '{{ view.redirect_url|safe }}';
+                }, 10000);
+        instead of just
+                 window.location.href = '{{ view.redirect_url|safe }}';
+
+{% endcomment %}
+

--- a/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPageExample1ForOTree140.html
+++ b/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPageExample1ForOTree140.html
@@ -1,0 +1,133 @@
+{% extends 'otree/Base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+{% block head_title %}{{ title_text }}{% endblock %}
+
+{% block internal_styles %}
+    {{ block.super }}
+    <style>
+        body {
+            background-color: #c0c0c0;
+        }
+        .panel-primary {
+            background: white;
+            border: 1px solid #3b84c3;
+            border-radius: 5px;
+            box-shadow: 0 0 20px #999;
+            /*width: 940px; */
+            margin: 22px auto;
+        }
+        panel-body {
+            margin-top: 10px;
+        }
+        .page-header {
+           border: 1px solid #c0c0c0;
+        }
+        .otree-wait-page {
+            max-width:970px
+        }
+        .progress-bar {
+            width: 100%;
+        }
+    </style>
+{% endblock %}
+
+{% block body_main %}
+
+    <!-- use the selector .otree-wait-page -->
+    <div class="otree-wait-page container" id="otree-wait-page-body">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <!-- use the selector .otree-wait-page__title -->
+                <h3 class="otree-wait-page__title panel-title" id="otree-wait-page-title-text">{% block title %}{{ title_text }}{% endblock %}</h3>
+            </div>
+            <div class="panel-body">
+                <div id="_otree-server-error" class="alert alert-danger" style="display:none">
+                    {% blocktrans trimmed %}An error occurred. Please check the logs or ask the administrator for help.{% endblocktrans %}
+                </div>
+                <div id="error-traceback" class="alert alert-danger" style="display:none"></div>
+                {% block content %}
+                <!-- use the selector .otree-wait-page__body -->
+                <p class="otree-wait-page__body" id="otree-wait-page-body-text">{{ body_text }}</p>
+                {% endblock %}
+                <div class="progress progress-striped active">
+                    <div class="progress-bar" role="progressbar"></div>
+                </div>
+            </div>
+        </div>
+        {% if view.is_debug %}
+            {% include 'otree/includes/debug_info.html' %}
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block internal_scripts %}
+    {{ block.super }}
+    <!-- this is an HTML file rather than JavaScript static file because context variables need to be passed to it -->
+    <script type="text/javascript">
+    $(document).ready(function () {
+        var socket;
+        initWebSocket();
+        function initWebSocket() {
+            var ws_scheme = window.location.protocol == "https:" ? "wss" : "ws";
+            var ws_path = ws_scheme + '://' + window.location.host + "{{ view.socket_url|safe }}";
+            socket = new ReconnectingWebSocket(ws_path);
+            socket.onmessage = function(e) {
+                var data = JSON.parse(e.data);
+                // Handle errors
+                if (data.error) {
+                    // maybe the div's default text doesn't get shown
+                    $("#_otree-server-error").text(data.error);
+                    $("#_otree-server-error").show();
+                    if (data.traceback) {
+                        $("#error-traceback").html('<pre>' + data.traceback + '</pre>');
+                        $("#error-traceback").show();
+                    }
+                    return;
+                }
+                alert('Enough persons have arrived, you will be transfered to the next page; You will be invited to finish your study at the end of the experiment');
+                console.log('Received redirect message', e.data);
+                window.location.href = '{{ view.redirect_url|safe }}';
+            };
+            socket.onopen = function() {
+                console.log('WebSocket connected');
+            };
+            socket.onclose = function() {
+                console.log('WebSocket disconnected');
+            };
+        }
+        {% if view.group_by_arrival_time %}
+            {% comment %}
+            We should use an AJAX heartbeat rather than relying on just
+            refreshing the page, because on slow servers, this could take a long time,
+            and could be disruptive.
+            We can do this refresh frequently, without worrying about overloading the server
+            or disrupting the user.
+            And other wait pages in oTree don't refresh frequently, so we should be consistent.
+            The extra AJAX view doesn't really add much complexity.
+            Also it makes it easier for folks to test this functionality.
+            {% endcomment %}
+            function heartbeat() {
+                var args = {
+                    type: "GET",
+                    url: '{% url "ParticipantHeartbeatGBAT" participant.code %}',
+                    // necessary for IE
+                    cache: false
+                };
+                $.ajax(args);
+            }
+            var SECOND = 1000;
+            window.setInterval(heartbeat, 10 * SECOND);
+            {% comment %}
+            Refresh the whole page, because if we just used an AJAX heartbeat,
+            then someone could go offline then comes back online,
+            and then enough people would be online, but nothing happens because
+            try_to_regroup is not re-executed. that only happens with a full page load.
+            {% endcomment %}
+            window.setInterval(function() {
+                      window.location.reload();
+                    }, 60*SECOND);
+        {% endif %}
+     });
+     </script>
+ {% endblock %}

--- a/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPageExample2ForOTree140.html
+++ b/otree_mturk_utils/templates/otree_mturk_utils/GenericExtendedWaitPageExample2ForOTree140.html
@@ -1,0 +1,145 @@
+{% extends 'otree/Base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+{% block head_title %}{{ title_text }}{% endblock %}
+
+{% block internal_styles %}
+    {{ block.super }}
+    <style>
+        body {
+            background-color: #c0c0c0;
+        }
+        .panel-primary {
+            background: white;
+            border: 1px solid #3b84c3;
+            border-radius: 5px;
+            box-shadow: 0 0 20px #999;
+            /*width: 940px; */
+            margin: 22px auto;
+        }
+        panel-body {
+            margin-top: 10px;
+        }
+        .page-header {
+           border: 1px solid #c0c0c0;
+        }
+        .otree-wait-page {
+            max-width:970px
+        }
+        .progress-bar {
+            width: 100%;
+        }
+    </style>
+{% endblock %}
+
+{% block body_main %}
+
+    <!-- use the selector .otree-wait-page -->
+    <div class="otree-wait-page container" id="otree-wait-page-body">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <!-- use the selector .otree-wait-page__title -->
+                <h3 class="otree-wait-page__title panel-title" id="otree-wait-page-title-text">{% block title %}{{ title_text }}{% endblock %}</h3>
+            </div>
+            <div class="panel-body">
+                <div class="well" id="show-when-group-is-formed" style="display:none; color:red;">
+                    <b>Enough persons have arrived, you will be transfered to the next page; You will be invited to finish your study at the end of the experiment.</b>
+                </div>
+                <div id="_otree-server-error" class="alert alert-danger" style="display:none">
+                    {% blocktrans trimmed %}An error occurred. Please check the logs or ask the administrator for help.{% endblocktrans %}
+                </div>
+                <div id="error-traceback" class="alert alert-danger" style="display:none"></div>
+                {% block content %}
+                <!-- use the selector .otree-wait-page__body -->
+                <p class="otree-wait-page__body" id="otree-wait-page-body-text">{{ body_text }}</p>
+                {% endblock %}
+                <div class="progress progress-striped active">
+                    <div class="progress-bar" role="progressbar"></div>
+                </div>
+
+            </div>
+        </div>
+        {% if view.is_debug %}
+            {% include 'otree/includes/debug_info.html' %}
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block internal_scripts %}
+    {{ block.super }}
+    <!-- this is an HTML file rather than JavaScript static file because context variables need to be passed to it -->
+    <script type="text/javascript">
+    $(document).ready(function () {
+        var socket;
+        initWebSocket();
+        function initWebSocket() {
+            var ws_scheme = window.location.protocol == "https:" ? "wss" : "ws";
+            var ws_path = ws_scheme + '://' + window.location.host + "{{ view.socket_url|safe }}";
+            socket = new ReconnectingWebSocket(ws_path);
+            socket.onmessage = function(e) {
+                var data = JSON.parse(e.data);
+                // Handle errors
+                if (data.error) {
+                    // maybe the div's default text doesn't get shown
+                    $("#_otree-server-error").text(data.error);
+                    $("#_otree-server-error").show();
+                    if (data.traceback) {
+                        $("#error-traceback").html('<pre>' + data.traceback + '</pre>');
+                        $("#error-traceback").show();
+                    }
+                    return;
+                }
+
+                console.log('Received redirect message', e.data);
+
+                $("#show-when-group-is-formed").show();
+                window.setInterval(function() {
+                      window.location.href = '{{ view.redirect_url|safe }}';
+                    }, 10000);
+               
+                
+
+
+            };
+            socket.onopen = function() {
+                console.log('WebSocket connected');
+            };
+            socket.onclose = function() {
+                console.log('WebSocket disconnected');
+            };
+        }
+        {% if view.group_by_arrival_time %}
+            {% comment %}
+            We should use an AJAX heartbeat rather than relying on just
+            refreshing the page, because on slow servers, this could take a long time,
+            and could be disruptive.
+            We can do this refresh frequently, without worrying about overloading the server
+            or disrupting the user.
+            And other wait pages in oTree don't refresh frequently, so we should be consistent.
+            The extra AJAX view doesn't really add much complexity.
+            Also it makes it easier for folks to test this functionality.
+            {% endcomment %}
+            function heartbeat() {
+                var args = {
+                    type: "GET",
+                    url: '{% url "ParticipantHeartbeatGBAT" participant.code %}',
+                    // necessary for IE
+                    cache: false
+                };
+                $.ajax(args);
+            }
+            var SECOND = 1000;
+            window.setInterval(heartbeat, 10 * SECOND);
+            {% comment %}
+            Refresh the whole page, because if we just used an AJAX heartbeat,
+            then someone could go offline then comes back online,
+            and then enough people would be online, but nothing happens because
+            try_to_regroup is not re-executed. that only happens with a full page load.
+            {% endcomment %}
+            window.setInterval(function() {
+                      window.location.reload();
+                    }, 60*SECOND);
+        {% endif %}
+     });
+     </script>
+ {% endblock %}


### PR DESCRIPTION
First introduction of a intermediary waitpage in the extension path, so that experimenters can add their own js behavior


Description not yet added to the readme file, but general idea is described in a comment in the, otherwise empty - except extends - GenericExtendedWaitPage.
